### PR TITLE
Add Mi to kubernetes max-body-size example

### DIFF
--- a/daprdocs/content/en/operations/configuration/increase-request-size.md
+++ b/daprdocs/content/en/operations/configuration/increase-request-size.md
@@ -52,7 +52,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "myapp"
         dapr.io/app-port: "8000"
-        dapr.io/max-body-size: "16"
+        dapr.io/max-body-size: "16Mi"
 #...
 ```
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated an example for the max-body-size K8 config option which was missing the "Mi" component without this it defaults to bytes which is misleading considering the page specifies
> This tells Dapr to set the maximum request body size to `16` MB for both HTTP and gRPC requests.


## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
